### PR TITLE
chore: update github actions to always use latest chrome version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: refs_heads_main-913317
+          chrome-version: 126
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
           node-version: '14.x'
 
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: 126
+        uses: browser-actions/setup-chrome@v1
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
- updated `chrome` in github actions to `v126`